### PR TITLE
5.7.3 snapshot

### DIFF
--- a/nuxeo-platform-login-digest/pom.xml
+++ b/nuxeo-platform-login-digest/pom.xml
@@ -45,6 +45,13 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
+
+      <dependency>
+          <groupId>net.sf.opencsv</groupId>
+          <artifactId>opencsv</artifactId>
+      </dependency>
+
+
   </dependencies>
 
 </project>

--- a/nuxeo-platform-login-digest/src/main/java/org/nuxeo/ecm/ui/web/auth/digest/DigestAuthenticator.java
+++ b/nuxeo-platform-login-digest/src/main/java/org/nuxeo/ecm/ui/web/auth/digest/DigestAuthenticator.java
@@ -17,16 +17,22 @@
 package org.nuxeo.ecm.ui.web.auth.digest;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import au.com.bytecode.opencsv.CSVReader;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.nuxeo.ecm.platform.api.login.UserIdentificationInfo;
 import org.nuxeo.ecm.platform.ui.web.auth.interfaces.NuxeoAuthenticationPlugin;
 
@@ -35,15 +41,20 @@ import org.nuxeo.ecm.platform.ui.web.auth.interfaces.NuxeoAuthenticationPlugin;
  */
 public class DigestAuthenticator implements NuxeoAuthenticationPlugin {
 
+    private static final Log log = LogFactory.getLog(DigestAuthenticator.class);
+
     protected static final String DEFAULT_REALMNAME = "NUXEO";
 
     protected static final long DEFAULT_NONCE_VALIDITY_SECONDS = 1000;
 
-    protected static final String COMMA_SEPARATOR = ",";
-
-    protected static final String EQUAL_SEPARATOR = "=";
-
-    protected static final String QUOTE = "\"";
+    /*
+     * match the first portion up until an equals sign
+     * followed by optional white space of quote chars
+     * and ending with an optional quote char
+     * Pattern is a thread-safe class and so can be defined statically
+     * Example pair pattern: username="kirsty"
+     */
+    protected static final Pattern PAIR_ITEM_PATTERN = Pattern.compile("^(.*?)=([\\s\"]*)?(.*)(\")?$");
 
     protected static final String REALM_NAME_KEY = "RealmName";
 
@@ -137,18 +148,33 @@ public class DigestAuthenticator implements NuxeoAuthenticationPlugin {
     }
 
     public static Map<String, String> splitParameters(String auth) {
-        String[] array = auth.split(COMMA_SEPARATOR);
-        if (array == null || array.length == 0) {
-            return null;
-        }
         Map<String, String> map = new HashMap<String, String>();
-        for (String item : array) {
-            item = StringUtils.remove(item, QUOTE);
-            String[] parts = item.split(EQUAL_SEPARATOR, 2);
-            if (parts == null) {
-                continue;
+        CSVReader reader = null;
+        try {
+            reader = new CSVReader(new StringReader(auth));
+            String[] array = null;
+            try {
+                array = reader.readNext();
+            } catch (IOException e) {
+                log.error(e.getMessage(),e);
+                return map;
             }
-            map.put(parts[0].trim(), parts[1].trim());
+            for (String itemPairStr : array) {
+                Matcher match = PAIR_ITEM_PATTERN.matcher(itemPairStr);
+                if (match.find()) {
+                    String key = match.group(1);
+                    String value = match.group(3);
+                    map.put(key.trim(), value.trim());
+                } else {
+                    log.warn("Could not parse item pair " + itemPairStr);
+                }
+            }
+        } finally {
+            if (reader!=null) {
+                try {
+                    reader.close();
+                } catch (IOException io) { }
+            }
         }
         return map;
     }

--- a/nuxeo-platform-login-digest/src/test/java/org/nuxeo/ecm/ui/web/auth/digest/DigestAuthenticatorTest.java
+++ b/nuxeo-platform-login-digest/src/test/java/org/nuxeo/ecm/ui/web/auth/digest/DigestAuthenticatorTest.java
@@ -12,14 +12,12 @@
  * Lesser General Public License for more details.
  *
  * Contributors:
- *     Gagnavarslan ehf
+ *     Thomas Haines
  */
 package org.nuxeo.ecm.ui.web.auth.digest;
 
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -27,12 +25,6 @@ import org.junit.Test;
  * Nuxeo Authenticator for HTTP Digest Access Authentication (RFC 2617).
  */
 public class DigestAuthenticatorTest {
-  protected static final String COMMA_SEPARATOR = ",";
-  protected static final String QUOTE = "\"";
-  protected static final String EQUAL_SEPARATOR = "=";
-
-  private static final Log log = LogFactory
-      .getLog(DigestAuthenticatorTest.class);
 
   @Test
   public void testWithComma() {

--- a/nuxeo-platform-login-digest/src/test/java/org/nuxeo/ecm/ui/web/auth/digest/DigestAuthenticatorTest.java
+++ b/nuxeo-platform-login-digest/src/test/java/org/nuxeo/ecm/ui/web/auth/digest/DigestAuthenticatorTest.java
@@ -1,0 +1,61 @@
+/*
+ * (C) Copyright 2010-2011 Nuxeo SA (http://nuxeo.com/) and contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser General Public License
+ * (LGPL) version 2.1 which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/lgpl.html
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * Contributors:
+ *     Gagnavarslan ehf
+ */
+package org.nuxeo.ecm.ui.web.auth.digest;
+
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Nuxeo Authenticator for HTTP Digest Access Authentication (RFC 2617).
+ */
+public class DigestAuthenticatorTest {
+  protected static final String COMMA_SEPARATOR = ",";
+  protected static final String QUOTE = "\"";
+  protected static final String EQUAL_SEPARATOR = "=";
+
+  private static final Log log = LogFactory
+      .getLog(DigestAuthenticatorTest.class);
+
+  @Test
+  public void testWithComma() {
+    String uri = "/nuxeo/site/dav/Patricia/Documents/2/1425/AU/00/G511_Oct_09,_2013_68999.doc";
+    String auth2 = "username=\"kirsty\",realm=\"NUXEO\",nonce=\"MTM4MTI4ODc4NDYyNTo0ZTcxNTcyYmNmNjI1YWMxOTk4MTllM2JhOTNmOTFjMw==\",uri=\""
+        + uri
+        + "\",cnonce=\"d30fb25c5345b787bccd677d1cb93bd6\",nc=00000001,response=\"c8b18e0e7e6a55fe6a72ada845f7f1c7\",qop=\"auth\"";
+    Map<String, String> map = DigestAuthenticator.splitParameters(auth2);
+    Assert.assertTrue(map.keySet().size() == 8);
+    Assert.assertTrue(map.keySet().contains("uri"));
+    Assert.assertTrue(map.get("uri").equals(uri));
+  }
+
+  @Test
+  public void testWithoutComma() {
+    String uri = "/nuxeo/site/dav/Patricia/Documents/2/1425/AU/00/G511_Oct_09_2013_68999.doc";
+    String auth2 = "username=\"kirsty\",realm=\"NUXEO\",nonce=\"MTM4MTI4ODc4NDYyNTo0ZTcxNTcyYmNmNjI1YWMxOTk4MTllM2JhOTNmOTFjMw==\",uri=\""
+        + uri
+        + "\",cnonce=\"d30fb25c5345b787bccd677d1cb93bd6\",nc=00000001,response=\"c8b18e0e7e6a55fe6a72ada845f7f1c7\",qop=\"auth\"";
+    Map<String, String> map = DigestAuthenticator.splitParameters(auth2);
+    Assert.assertTrue(map.keySet().size() == 8);
+    Assert.assertTrue(map.keySet().contains("uri"));
+    Assert.assertTrue(map.get("uri").equals(uri));
+  }
+
+}


### PR DESCRIPTION
This fixes a critical bug with DigestAuthentication.  If the file name contains a comma, then the parser fails.
Refer here http://opencsv.sourceforge.net/#what-is-opencsv, "opencsv supports all the basic csv-type things you're likely to want to do: Ignoring commas in quoted elements".  By simply using String.split(",") previously, if the filename contains a comma, the parser becomes understandably confused.
I have pushed two changes: one is to use the initial division of tokens using CSV, then, the second is to only remove the start or end quotes, but not to remove quotes in the string itself.
